### PR TITLE
doc: note that libcunit is required in order to build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,7 @@
 To build the entire project, just execute make from the parent directory.
 Individual source sub-directories can also be build with make.
 The following make targets can be used: clean, all, test.
+
+CUnit is required (currently) - ensure that libcunit1 is installed.
+
 Refer to the README.md for more details.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ headers per library.
 
 The project or individual libraries can be built, cleaned, and tested as follows:
 
+CUnit is required (currently) - ensure that libcunit1 is installed.
 
 ### Building
 


### PR DESCRIPTION
Add notes that libcunit is required to build - it is, and nothing tells us that except a compile failure...